### PR TITLE
SPDX expression

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "undefined"
   ],
   "author": "Remy Sharp",
-  "license": "MIT / http://rem.mit-license.org",
+  "license": "MIT",
   "devDependencies": {
     "mocha": "~1.16.2"
   }


### PR DESCRIPTION
Only the old `licenses` property allowed URLs. The `license` property requires a valid SPDX expression. Details: https://docs.npmjs.com/files/package.json#license
