### PR TITLE
Fixed for path parsing problem

### DIFF
--- a/lib/undefsafe.js
+++ b/lib/undefsafe.js
@@ -1,7 +1,13 @@
 'use strict';
 
 function undefsafe(obj, path, value) {
-  var parts = path.split('.');
+  var parts = path
+    .match(/^([_$a-zA-Z\xA0-\uFFFF][_$a-zA-Z0-9\xA0-\uFFFF]*)|(\[['"](.+?)['"]\])|(\[([0-9]+?)\])|(\.[_$a-zA-Z\xA0-\uFFFF][_$a-zA-Z0-9\xA0-\uFFFF]*)/g)
+    .map(x => {
+      if(x[0] === '.') return x.substr(1);
+      if(x[0] === '[' && x.substr(-1) === ']') return x.substring(2, x.length-2);
+      return x;
+    });
   var key = null;
   var type = typeof obj;
   var root = obj;


### PR DESCRIPTION
Fixed for this issue: https://github.com/remy/jsonbin/issues/13

This PR comply to JavaScript standard way to get property.   So the path must be well-formed.  This PR can't pass all the tests especially for most of the malformed/customized object getter path formats.