### PR TITLE
Update debug library to v4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,10 @@ cache:
 notifications:
   email: false
 node_js:
-  - '4'
+  - '6'
+  - '8'
+  - '10'
+  - '12'
 before_install:
   - npm i -g npm@^2.0.0
 before_script:

--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
     "tap-only": "0.0.5"
   },
   "dependencies": {
-    "debug": "^2.2.0"
+    "debug": "^4.1.1"
   }
 }


### PR DESCRIPTION
Update library to use debug@4 as debug@3 is no longer maintained. Unfortunately it required at least node 6, so getting this update probably requires a major version bump.